### PR TITLE
Use contained Questionnaire.url for identification

### DIFF
--- a/input/pagecontent/adaptive.xml
+++ b/input/pagecontent/adaptive.xml
@@ -73,9 +73,7 @@
                 "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-adapt"
               ]
             },
-            "identifier": {
-             <i>// identifier system and value for "Physical Function 2.0" questionnaire</i>
-            },
+            "url": <i>// identifier system and value for "Physical Function 2.0" questionnaire</i>
 
             <b>//no items since initiating the adaptive questionnaire</b>
             ...
@@ -113,9 +111,7 @@
                 "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-adapt"
               ]
             },
-            "identifier": {
-             <i>// identifier system and value for "Physical Function 2.0" questionnaire</i>
-            },
+            "url": <i>// identifier system and value for "Physical Function 2.0" questionnaire</i>
 
             <b>// First Item being sent back</b>
             "item": [
@@ -171,9 +167,7 @@
                 "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-adapt"
               ]
             },
-            "identifier": {
-             <i>// identifier system and value for "Physical Function 2.0" questionnaire</i>
-            },
+            "url": <i>// identifier system and value for "Physical Function 2.0" questionnaire</i>
 
             <b>// List items here that have been already administered.</b>
             "item": [
@@ -237,9 +231,7 @@
                 "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-adapt"
               ]
             },
-            "identifier": {
-              <i>// identifier system and value for "Physical Function 2.0" questionnaire</i>
-            },
+            "url": <i>// identifier system and value for "Physical Function 2.0" questionnaire</i>
 
             "item": [
             <b>// Item already administered</b>
@@ -332,9 +324,7 @@
                 "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-adapt"
               ]
             },
-            "identifier": {
-              <i>// identifier system and value for "Physical Function 2.0" questionnaire</i>
-            },
+            "url": <i>// identifier system and value for "Physical Function 2.0" questionnaire</i>
 
             "item": [
             <b>// Items already administered</b>


### PR DESCRIPTION
Per the conversation in Zulip https://chat.fhir.org/#narrow/stream/179255-questionnaire/topic/contained.20reference.20to.20an.20adaptive.20questionnaire/near/185126690, this changes the example to use the url `QuestionnaireResponse.contained[].Questionnaire.url` for identification of the questionnaire, instead of an `identifier`.